### PR TITLE
chore: drop support for node 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ sudo: false
 language: node_js
 node_js:
 - stable
+- '10'
+- '8'
 - '6'
-- '4'
 matrix:
   fast_finish: true
 branches:


### PR DESCRIPTION
BREAKING CHANGE: drop support for node 4