### PR TITLE
chore: drop support for node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
 - stable
 - '10'
 - '8'
-- '6'
 matrix:
   fast_finish: true
 branches:


### PR DESCRIPTION
Since standard-version drops support for ndoe 6 we need to do so as
well.

BREAKING CHANGE: drop support for node 6